### PR TITLE
Added "Default on copy" setting for elements (had to go in Access tab…

### DIFF
--- a/administrator/components/com_fabrik/language/en-GB/en-GB.com_fabrik.ini
+++ b/administrator/components/com_fabrik/language/en-GB/en-GB.com_fabrik.ini
@@ -1461,3 +1461,6 @@ COM_FABRIK_FIELD_CHECK_CUSTOM_LIST_LAYOUT_LABEL="Check Custom Layouts"
 
 COM_FABRIK_TRUNCATE_LENGTH_DESC="In Fabrik backend displays, some columns can be very wide (like element labels).  Set a non 0 value here to have Fabrik truncate those columns to a specific number of characters"
 COM_FABRIK_TRUNCATE_LENGTH_LABEL="Truncate Length"
+
+COM_FABRIK_FIELD_DEFAULT_ON_COPY_DESC="When copying a row (either with the list copy plugin, or the form Save as Copy), don't copy this element, rather use the normal default value"
+COM_FABRIK_FIELD_DEFAULT_ON_COPY_LABEL="Default on Copy"

--- a/administrator/components/com_fabrik/models/forms/element.xml
+++ b/administrator/components/com_fabrik/models/forms/element.xml
@@ -688,6 +688,16 @@
 						<option value="0">JNO</option>
 						<option value="1">JYES</option>
 					</field>
+
+					<field name="default_on_copy"
+						   type="radio"
+						   class="btn-group"
+						   default="0"
+						   description="COM_FABRIK_FIELD_DEFAULT_ON_COPY_DESC"
+						   label="COM_FABRIK_FIELD_DEFAULT_ON_COPY_LABEL" >
+						<option value="0">JNO</option>
+						<option value="1">JYES</option>
+					</field>
 				</fieldset>
 
 	</fields>

--- a/components/com_fabrik/models/element.php
+++ b/components/com_fabrik/models/element.php
@@ -1347,6 +1347,17 @@ class PlgFabrik_Element extends FabrikPlugin
 	}
 
 	/**
+	 * Should the element ignore a form or list row copy, and use the default regardless
+	 *
+	 * @return bool
+	 */
+	public function defaultOnCopy()
+	{
+		$params = $this->getParams();
+		return $params->get('default_on_copy', '0') === '1';
+	}
+
+	/**
 	 * This really does get just the default value (as defined in the element's settings)
 	 *
 	 * @param   array $data Form data
@@ -6701,7 +6712,7 @@ class PlgFabrik_Element extends FabrikPlugin
 	 */
 	public function onCopyRow($val)
 	{
-		return $val;
+		return $this->defaultOnCopy() ? $this->default : $val;
 	}
 
 	/**
@@ -6713,7 +6724,7 @@ class PlgFabrik_Element extends FabrikPlugin
 	 */
 	public function onSaveAsCopy($val)
 	{
-		return $val;
+		return $this->defaultOnCopy() ? $this->default : $val;
 	}
 
 	/**

--- a/plugins/fabrik_element/date/date.php
+++ b/plugins/fabrik_element/date/date.php
@@ -2283,6 +2283,11 @@ class PlgFabrik_ElementDate extends PlgFabrik_ElementList
 	 */
 	public function onCopyRow($val)
 	{
+		if ($this->defaultOnCopy())
+		{
+			$val = $this->getFrontDefaultValue();
+		}
+
 		if (!FabrikWorker::isDate($val))
 		{
 			return $val;
@@ -2304,6 +2309,18 @@ class PlgFabrik_ElementDate extends PlgFabrik_ElementList
 		}
 
 		return $val;
+	}
+
+	/**
+	 * Called when save as copy form button clicked
+	 *
+	 * @param   mixed $val value to copy into new record
+	 *
+	 * @return  mixed  value to copy into new record
+	 */
+	public function onSaveAsCopy($val)
+	{
+		return $this->onCopyRow($val);
 	}
 
 	/**


### PR DESCRIPTION
…, don't ask - well, as you asked, it has to go in a param group, can't go in main settings), if set to Yes and element is being copied (with form Save as Copy or list copy plugin) will use the normal default rather than copied value.